### PR TITLE
Add CDN support

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: attlii
 Tags: media, image, blur, base64, library
 Requires at least: 5.6
 Tested up to: 5.8.2
-Stable tag: 1.0.1
+Stable tag: 1.1.0
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -61,3 +61,6 @@ add_filter("image-blur-modify-gaussian-blur-strength", "modify_gaussian_blur_str
 
 = 1.0.1 (2021-11-30): =
 - Remove development related files from plugin directory
+
+= 1.1.0 (2021-12-02): =
+- Add CDN support

--- a/image-blur.php
+++ b/image-blur.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Image Blur
  * Plugin URI:        https://github.com/AttLii/image-blur
  * Description:       Generates base64 encoded, downscaled and blurred versions of media library's images, which can be used f.e. as a placeholder.
- * Version:           1.0.1
+ * Version:           1.1.0
  * Requires at least: 5.6
  * Requires PHP:      7.4
  * Author:            Atte Liimatainen

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -13,6 +13,7 @@
 		<exclude name="Squiz.Commenting.FileComment.MissingPackageTag" />
 		<exclude name="WordPress.Files.FileName.NotHyphenatedLowercase" />
 		<exclude name="WordPress.Files.FileName.InvalidClassFileName" />
+		<exclude name="WordPress.PHP.DisallowShortTernary.Found" />
 		<exclude name="WordPress.PHP.YodaConditions.NotYoda" />
 	</rule>
 </ruleset>

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -104,15 +104,25 @@ class Plugin {
 					list( 'basedir' => $basedir ) = wp_upload_dir();
 					$sizes = AttachmentParser::parse_sizes_from_metadata( $metadata );
 					foreach ( $sizes as $size => $path ) {
-						$image = $create( "$basedir/$path" );
-						$image = $this->image_manipulation_service->process_image( $mime, $image );
 
-						ob_start();
-						$output( $image );
-						$contents = ob_get_clean();
+						$image = @$create( "$basedir/$path" );
+						if ( ! $image ) {
+							$url = $this->image_repository->get_url_for_size( $id, $size );
+							if ( $url ) {
+								$image = @$create( $url );
+							}
+						}
 
-						$data = base64_encode( $contents );
-						$this->image_blur_repository->set( $id, $size, $data );
+						if ( $image ) {
+							$image = $this->image_manipulation_service->process_image( $mime, $image );
+
+							ob_start();
+							$output( $image );
+							$contents = ob_get_clean();
+
+							$data = base64_encode( $contents );
+							$this->image_blur_repository->set( $id, $size, $data );
+						}
 					}
 				}
 			}

--- a/src/Repository/Image.php
+++ b/src/Repository/Image.php
@@ -70,4 +70,15 @@ class Image {
 	public function get_mime_type( int $id ) {
 		return get_post_mime_type( $id );
 	}
+
+	/**
+	 * Returns remote url for the attachment's id and size
+	 *
+	 * @param int    $id - attachment's id.
+	 * @param string $size - slug of the image size.
+	 * @return null|string - attachment's mime type.
+	 */
+	public function get_url_for_size( int $id, string $size ): ?string {
+		return wp_get_attachment_image_url( $id, $size ) ?: null;
+	}
 }

--- a/tests/unit/Repository/ImageTest.php
+++ b/tests/unit/Repository/ImageTest.php
@@ -107,4 +107,24 @@ final class ImageTest extends WP_Mock\Tools\TestCase {
 		$result = $this->repo->get_mime_type( 1 );
 		$this->assertEquals( $result, 'image/png' );
 	}
+
+	public function testGetUrlForSizeMethod() {
+		WP_Mock::userFunction( "wp_get_attachment_image_url", array(
+			"times" => 1,
+			"with" => array( 1, "full" ),
+			"return" => "https://cdn.client.com/wp-content/uploads/2021/12/merry-xmas.png"
+		) );
+
+		WP_Mock::userFunction( "wp_get_attachment_image_url", array(
+			"times" => 1,
+			"with" => array( 404, "weird-size-that-doesnt-exist" ),
+			"return" => false
+		) );
+
+		$result = $this->repo->get_url_for_size( 1, 'full' );
+		$this->assertEquals( $result, "https://cdn.client.com/wp-content/uploads/2021/12/merry-xmas.png" );
+
+		$result = $this->repo->get_url_for_size( 404, 'weird-size-that-doesnt-exist' );
+		$this->assertNull( $result );
+	}
 }


### PR DESCRIPTION
Plugin's code uses server path to get image content for processing. This change first tries this operation and if it fails, it tries getting the content using image's public url.

The reason for this addition is that it prepares plugin's code for environments that offload media library to CDN.

closes #18 