### PR TITLE
Requires autoload if class does not exist

### DIFF
--- a/image-blur.php
+++ b/image-blur.php
@@ -13,7 +13,9 @@
  */
 
 
-require_once 'vendor/autoload.php';
+if ( ! class_exists( '\\ImageBlur\\Plugin' ) ) {
+  require_once dirname( __FILE__ ) . '/vendor/autoload.php';
+}
 
 /**
  * Stop execution if not in Wordpress environment


### PR DESCRIPTION
This commit fixes an issue when using this plugin with a root autoload but the plugin was installed via zip upload (not using the composer at the root of the project).
